### PR TITLE
Fix Sphinx extension name in Quick start

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,7 +39,7 @@ Install both packages::
 
 Enable and configure the Sphinx extension in your ``conf.py`` file::
 
-    extensions.append("ocaml")
+    extensions.append("sphinxcontrib.ocaml")
     primary_domain = "ocaml"  # Optional
     ocaml_source_directories = ["src"]
     ocaml_findlib_packages = ["batteries", "js_of_ocaml"]


### PR DESCRIPTION
[The Quick start guide gives](https://github.com/jacquev6/sphinxcontrib-ocaml/blob/master/README.rst#quick-start) the name of the Sphinx extension as just `"ocaml"`. For me, this results in:

```
Extension error:
Could not import extension ocaml (exception: No module named ocaml)
```

[Looking in this repo's own `conf.py`](https://github.com/jacquev6/sphinxcontrib-ocaml/blob/4a12600f4e3155661cdd5df251f7aba44ec1e296/doc/conf.py#L31), I see that it should probably be called `sphinxcontrib.ocaml`, which works on my installation. Hence this patch :)