### PR TITLE
.gitignore .install file generated by Jbuilder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ _build/
 __pycache__/
 /dist/
 .merlin
+*.install


### PR DESCRIPTION
Jbuilder generates `sphinxcontrib-ocaml.install` in the repository root upon build.